### PR TITLE
New spectrogram scaling

### DIFF
--- a/classification/dataset.py
+++ b/classification/dataset.py
@@ -242,9 +242,23 @@ class PyhaDFDataset(Dataset):
         mel = self.mel_spectogram(audio)
         # Convert to Image
         image = torch.stack([mel, mel, mel])
+        
+        # Convert to decibels
+        # Log scale the power
+        decibel_convert = audtr.AmplitudeToDB(stype="power")
+        image = decibel_convert(image)
+        
         # Normalize Image
-        max_val = torch.abs(image).max() + 0.000001
-        image = image / max_val
+        # Inspired by
+        # https://medium.com/@hasithsura/audio-classification-d37a82d6715
+        mean = image.mean()
+        std = image.std()
+        image = (image - mean) / (std + 1e-6)
+        
+        # Sigmoid to get 0 to 1 scaling (0.5 becomes mean)
+        image = torch.sigmoid(image)
+
+
         return image
 
     def __getitem__(self, index): #-> Any:

--- a/classification/dataset.py
+++ b/classification/dataset.py
@@ -257,8 +257,6 @@ class PyhaDFDataset(Dataset):
         
         # Sigmoid to get 0 to 1 scaling (0.5 becomes mean)
         image = torch.sigmoid(image)
-
-
         return image
 
     def __getitem__(self, index): #-> Any:

--- a/classification/models/timm_model.py
+++ b/classification/models/timm_model.py
@@ -30,7 +30,11 @@ class TimmModel(nn.Module):
         super().__init__()
         self.num_classes = num_classes
         # See config.py for list of recommended models
-        self.model = timm.create_model(model_name, pretrained=pretrained, num_classes=num_classes)
+        self.model = timm.create_model(
+            model_name,
+            pretrained=pretrained,
+            num_classes=num_classes,
+            drop_rate=0.5)
         self.loss_fn = None
         self.without_logits = cfg.loss_fnc == "BCE"
 


### PR DESCRIPTION
Adds
- Dropout
- Convert spectrogram to db scale
- Zscoring spectrogram
- Sigmoid zscores to get 0 to 1


Replace dividing the whole spectrogram by max which caused bad inputs to ruin image. 