### PR TITLE
Add more audio file formats to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,10 @@ config.yml
 data/*
 *.mp3
 *.wav
+*.flac
+*.ogg
+*.m4a
+*.opus
 *.csv
 *.log
 *.pt


### PR DESCRIPTION
- flac
- ogg
- opus
- m4a

I was using flac files for testing sets and it got annoying