### PR TITLE
Sliding pyha chunks hotfix

### DIFF
--- a/pyha_analyzer/chunking_methods/sliding_chunks.py
+++ b/pyha_analyzer/chunking_methods/sliding_chunks.py
@@ -46,7 +46,7 @@ def convolving_chunk(row:dict,
         return []
     
     # calculate valid offsets for short annotations
-    if (duration_s <= chunk_length_s):
+    if duration_s <= chunk_length_s:
         # start of clip
         if (offset_s + chunk_length_s) < float(row['CLIP LENGTH']) and not only_slide:
             starts.append(offset_s)

--- a/pyha_analyzer/chunking_methods/sliding_chunks.py
+++ b/pyha_analyzer/chunking_methods/sliding_chunks.py
@@ -52,7 +52,7 @@ def convolving_chunk(row:dict,
             starts.append(offset_s)
         # middle of clip
         if end_s - chunk_length_s/2.0 > 0 and end_s + chunk_length_s/2.0 < row['CLIP LENGTH']:
-            starts.append(end_s - chunk_length_s/2.0)
+            starts.append((offset_s + end_s)/2.0 - chunk_length_s/2.0)
         # end of clip
         if end_s - chunk_length_s > 0 and not only_slide:
             starts.append(end_s - chunk_length_s)

--- a/pyha_analyzer/chunking_methods/sliding_chunks.py
+++ b/pyha_analyzer/chunking_methods/sliding_chunks.py
@@ -46,15 +46,15 @@ def convolving_chunk(row:dict,
         return []
     
     # calculate valid offsets for short annotations
-    if (duration_s <= chunk_length_s) and not only_slide:
+    if (duration_s <= chunk_length_s):
         # start of clip
-        if (offset_s + chunk_length_s) < float(row['CLIP LENGTH']):
+        if (offset_s + chunk_length_s) < float(row['CLIP LENGTH']) and not only_slide:
             starts.append(offset_s)
         # middle of clip
         if end_s - chunk_length_s/2.0 > 0 and end_s + chunk_length_s/2.0 < row['CLIP LENGTH']:
             starts.append(end_s - chunk_length_s/2.0)
         # end of clip
-        if end_s - chunk_length_s > 0:
+        if end_s - chunk_length_s > 0 and not only_slide:
             starts.append(end_s - chunk_length_s)
     # calculate valid offsets for long annotations
     else:


### PR DESCRIPTION
Ok so sliding chunking was discarding annotations less than 0.45 because `0.45 + (0.4 margin) + (0.4 margin) < 1.25` which is less than half of `chunk_length * (1-overlap) = 2.5` so it was getting discarded by the round function. This hotfix fixes that by diverting the chunking method to just center on short annotations when `only_slide=True`.